### PR TITLE
remove extra helmet middleware

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,6 @@ export class Server {
     app.use(bodyParser.urlencoded({ extended: true }));
     app.use(compress());
     app.use(helmet());
-    app.use(helmet());
     app.use(authMiddleware);
     app.use(
       cors({


### PR DESCRIPTION
There's an extra call to `app.use(helmet())` in the server.