### PR TITLE
Deprecate POST /library/bookmarks

### DIFF
--- a/src/api/LibraryRouter.ts
+++ b/src/api/LibraryRouter.ts
@@ -47,6 +47,9 @@ export class LibraryRouter implements ILibraryRouter {
     router.post('/bookmarks', middleWareInit, (req, res, next) =>
       this._controller.getAllUserBookmarks(req, res, next).catch(next),
     );
+    router.get('/bookmarks', middleWareInit, (req, res, next) =>
+      this._controller.getAllUserBookmarks(req, res, next).catch(next),
+    );
     router.put('/bookmark', middleWareInit, (req, res, next) =>
       this._controller.upsertBookmark(req, res, next).catch(next),
     );

--- a/src/controllers/LibraryController.ts
+++ b/src/controllers/LibraryController.ts
@@ -200,7 +200,16 @@ export class LibraryController implements ILibraryController {
         user_id: user.id_user,
         key: relativePath,
       });
-      return res.json({ bookmarks });
+      const response: { bookmarks: Bookmark[]; warning?: string } = {
+        bookmarks,
+      };
+      if (req.method === 'POST') {
+        response.warning =
+          'DEPRECATED: Using POST for /library/bookmarks is deprecated and ' +
+          'will be removed in the future. Please use GET.';
+        console.error(response.warning, user.id_user);
+      }
+      return res.json(response);
     } catch (err) {
       res.status(400).json({ message: err.message });
       return;


### PR DESCRIPTION
Fixes #6.

I added a call to `console.error` so that we can see how many clients will be affected if the `POST` usage is removed, but this will probably cause too much logging for too long. I think it'd be better to hit Sentry or something. I can remove that line if we have a better way to do it.