### PR TITLE
Add option to exclude lastItemPlayed on /library

### DIFF
--- a/src/controllers/LibraryController.ts
+++ b/src/controllers/LibraryController.ts
@@ -29,12 +29,15 @@ export class LibraryController implements ILibraryController {
     res: IResponse,
   ): Promise<IResponse> {
     try {
-      const { relativePath, sign } = req.query;
+      const { relativePath, sign, noLastItemPlayed } = req.query;
       const user = req.user;
       const path = `${user.email}/${relativePath ? relativePath : ''}`;
       const content = await this._libraryService.GetLibrary(user, path, sign);
       let lastItemPlayed;
-      if (!relativePath || relativePath === '/' || relativePath === '') {
+      if (
+        (!relativePath || relativePath === '/' || relativePath === '') &&
+        !noLastItemPlayed
+      ) {
         lastItemPlayed = await this._libraryService.dbGetLastItemPlayed(
           user,
           sign,


### PR DESCRIPTION
Fixes #5.

To maintain backwards compatibility, you have to explicitly exclude it with the `noLastItemPlayed` query param. Not the most elegant, but it does allow for a more cache-friendly way to GET /library.