### PR TITLE
Updating externa_id on delete account

### DIFF
--- a/src/database/migrations/20260221021450_add_suffix_to_inactive_external_ids.ts
+++ b/src/database/migrations/20260221021450_add_suffix_to_inactive_external_ids.ts
@@ -1,0 +1,64 @@
+import type { Knex } from "knex";
+
+const BATCH_SIZE = 1000;
+const TABLE_NAME = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    let count = 0;
+    let batch;
+
+    do {
+        batch = await knex(TABLE_NAME)
+            .select('id_user')
+            .where('active', false)
+            .andWhereNot('external_id', 'like', '%-deleted%')
+            .limit(BATCH_SIZE);
+
+        if (batch.length > 0) {
+            const ids = batch.map((row: { id_user: number | string }) => row.id_user);
+
+            await knex(TABLE_NAME)
+                .whereIn('id_user', ids)
+                .update({
+                    external_id: knex.raw(
+                        "?? || '-deleted' || CAST(EXTRACT(EPOCH FROM ??) AS BIGINT)", 
+                        ['external_id', 'updated_at']
+                    )
+                });
+
+            count += batch.length;
+            console.log(`[UP] Progress: Updated ${count} rows...`);
+        }
+    } while (batch.length === BATCH_SIZE);
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    let count = 0;
+    let batch;
+
+    do {
+        batch = await knex(TABLE_NAME)
+            .select('id_user')
+            .where('active', false)
+            .andWhere('external_id', 'like', '%-deleted%')
+            .limit(BATCH_SIZE);
+
+        if (batch.length > 0) {
+            const ids = batch.map((row: { id_user: number | string }) => row.id_user);
+
+            await knex(TABLE_NAME)
+                .whereIn('id_user', ids)
+                .update({
+                    external_id: knex.raw(
+                        "REGEXP_REPLACE(??, '-deleted[0-9]+$', '')", 
+                        ['external_id']
+                    )
+                });
+
+            count += batch.length;
+            console.log(`[DOWN] Progress: Reverted ${count} rows...`);
+        }
+    } while (batch.length === BATCH_SIZE);
+}
+

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -228,6 +228,9 @@ export class UserServices {
           email: tx.raw(
             `concat(users.email, '-deleted', '${moment().unix()}')`,
           ),
+          external_id: tx.raw(
+            `concat(users.external_id, '-deleted', '${moment().unix()}')`,
+          )
         })
         .where({
           active: true,


### PR DESCRIPTION
Updating external_id with '-deleted{timestamp}' suffix to allow users with Apple ID to create new accounts after deleting theirs