### PR TITLE
Soft Delete allows unique email and external id while active

### DIFF
--- a/src/database/migrations/20260225201011_add_soft_deletes_to_users_and_auth_methods.ts
+++ b/src/database/migrations/20260225201011_add_soft_deletes_to_users_and_auth_methods.ts
@@ -1,0 +1,68 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        UPDATE auth_methods
+            SET active = false
+            FROM users
+            WHERE auth_methods.user_id = users.id_user 
+            AND users.active = false 
+            AND auth_methods.active = true;
+    `);
+    
+    await knex.raw(`
+        ALTER TABLE users DROP CONSTRAINT IF EXISTS users_user_mail_unique;
+        ALTER TABLE users DROP CONSTRAINT IF EXISTS users_public_id_unique;
+
+        CREATE UNIQUE INDEX users_email_active_unique ON users (email) WHERE active = true;
+        CREATE UNIQUE INDEX users_external_id_active_unique ON users (external_id) WHERE active = true;
+
+        ALTER TABLE auth_methods DROP CONSTRAINT IF EXISTS auth_methods_auth_type_external_id_unique;
+
+        CREATE UNIQUE INDEX auth_methods_auth_type_external_id_active_unique ON auth_methods (external_id, auth_type) WHERE active = true;
+    `);
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        DROP INDEX IF EXISTS users_email_active_unique;
+        DROP INDEX IF EXISTS users_external_id_active_unique;
+        DROP INDEX IF EXISTS auth_methods_auth_type_external_id_active_unique;
+    `);
+
+    await knex.raw(`
+        UPDATE users 
+        SET 
+        email = CASE 
+            WHEN email NOT LIKE '%-deleted%' 
+            THEN email || '-deleted' || (EXTRACT(EPOCH FROM created_at)::BIGINT)
+            ELSE email 
+        END,
+        external_id = CASE 
+            WHEN external_id NOT LIKE '%-deleted%' 
+            THEN external_id || '-deleted' || (EXTRACT(EPOCH FROM created_at)::BIGINT)
+            ELSE external_id 
+        END
+        WHERE active = false;
+    `);
+
+    await knex.raw(`
+        UPDATE auth_methods 
+        SET 
+        external_id = CASE 
+            WHEN external_id NOT LIKE '%-deleted%' 
+            THEN external_id || '-deleted' || (EXTRACT(EPOCH FROM created_at)::BIGINT)
+            ELSE external_id 
+        END
+        WHERE active = false;
+    `);
+
+    await knex.raw(`
+        ALTER TABLE users ADD CONSTRAINT users_user_mail_unique UNIQUE (email);
+        ALTER TABLE users ADD CONSTRAINT users_public_id_unique UNIQUE (external_id);
+        ALTER TABLE auth_methods ADD CONSTRAINT auth_methods_auth_type_external_id_unique UNIQUE (external_id);
+    `);
+}
+

--- a/src/database/migrations/20260225201011_add_soft_deletes_to_users_and_auth_methods.ts
+++ b/src/database/migrations/20260225201011_add_soft_deletes_to_users_and_auth_methods.ts
@@ -20,7 +20,7 @@ export async function up(knex: Knex): Promise<void> {
 
         ALTER TABLE auth_methods DROP CONSTRAINT IF EXISTS auth_methods_auth_type_external_id_unique;
 
-        CREATE UNIQUE INDEX auth_methods_auth_type_external_id_active_unique ON auth_methods (external_id, auth_type) WHERE active = true;
+        CREATE UNIQUE INDEX auth_methods_auth_type_external_id_active_unique ON auth_methods (auth_type, external_id) WHERE active = true;
     `);
 }
 
@@ -62,7 +62,7 @@ export async function down(knex: Knex): Promise<void> {
     await knex.raw(`
         ALTER TABLE users ADD CONSTRAINT users_user_mail_unique UNIQUE (email);
         ALTER TABLE users ADD CONSTRAINT users_public_id_unique UNIQUE (external_id);
-        ALTER TABLE auth_methods ADD CONSTRAINT auth_methods_auth_type_external_id_unique UNIQUE (external_id);
+        ALTER TABLE auth_methods ADD CONSTRAINT auth_methods_auth_type_external_id_unique UNIQUE (auth_type, external_id);
     `);
 }
 

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -213,7 +213,7 @@ export class UserServices {
       await tx('user_devices')
         .update({
           updated_at: tx.fn.now(),
-          active: false
+          active: false,
         })
         .where({
           active: true,
@@ -231,7 +231,7 @@ export class UserServices {
       await tx('auth_methods')
         .update({
           updated_at: tx.fn.now(),
-          active: false
+          active: false,
         })
         .where({
           active: true,

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -205,7 +205,6 @@ export class UserServices {
         .update({
           updated_at: tx.fn.now(),
           active: false,
-          value: tx.raw("concat(user_params.value, '-deleted')"),
         })
         .where({
           active: true,
@@ -214,8 +213,7 @@ export class UserServices {
       await tx('user_devices')
         .update({
           updated_at: tx.fn.now(),
-          active: false,
-          session: tx.raw("concat(user_devices.session, '-deleted')"),
+          active: false
         })
         .where({
           active: true,
@@ -225,13 +223,19 @@ export class UserServices {
         .update({
           updated_at: tx.fn.now(),
           active: false,
-          email: tx.raw(
-            `concat(users.email, '-deleted', '${moment().unix()}')`,
-          ),
         })
         .where({
           active: true,
           id_user: user_id,
+        });
+      await tx('auth_methods')
+        .update({
+          updated_at: tx.fn.now(),
+          active: false
+        })
+        .where({
+          active: true,
+          user_id: user_id,
         });
       await tx.commit();
       return true;


### PR DESCRIPTION
migration to change unique constraint to avoid adding suffix deleted when deleting an account so users can log in again as new users