### PR TITLE
Library UUID

### DIFF
--- a/src/api/LibraryRouter.ts
+++ b/src/api/LibraryRouter.ts
@@ -59,6 +59,9 @@ export class LibraryRouter implements ILibraryRouter {
     router.get('/keys', middleWareInit, (req, res, next) =>
       this._controller.getUserLibraryKeys(req, res, next).catch(next),
     );
+    router.post('/uuids', middleWareInit, (req, res, next) =>
+      this._controller.postLibraryUuids(req, res, next).catch(next),
+    );
     return router;
   }
 }

--- a/src/controllers/LibraryController.ts
+++ b/src/controllers/LibraryController.ts
@@ -5,6 +5,7 @@ import { ILibraryController } from '../interfaces/ILibraryController';
 import { ILibraryService } from '../interfaces/ILibraryService';
 import { ILoggerService } from '../interfaces/ILoggerService';
 import { Bookmark, LibraryItem } from '../types/user';
+import { isValidUUID } from '../utils';
 
 @injectable()
 export class LibraryController implements ILibraryController {
@@ -33,7 +34,7 @@ export class LibraryController implements ILibraryController {
     res: IResponse,
   ): Promise<IResponse> {
     try {
-      const { relativePath, sign, noLastItemPlayed, forceLastItem } = req.query;
+      const { relativePath, uuid, sign, noLastItemPlayed, forceLastItem } = req.query;
       const user = req.user;
       const path = `${user.email}/${relativePath ? relativePath : ''}`;
 
@@ -41,7 +42,7 @@ export class LibraryController implements ILibraryController {
         withPresign: sign,
         appVersion: req.app_version,
       };
-      const content = await this._libraryService.GetLibrary(user, path, options);
+      const content = await this._libraryService.GetLibrary(user, path, options, uuid);
       let lastItemPlayed;
       if (
         ((!relativePath || relativePath === '/' || relativePath === '') &&
@@ -82,11 +83,11 @@ export class LibraryController implements ILibraryController {
     res: IResponse,
   ): Promise<IResponse> {
     try {
-      const { relativePath } = req.body;
+      const { relativePath, uuid } = req.body;
       const user = req.user;
 
       const updateFields = Object.keys(req.body).filter(
-        (key) => key !== 'relativePath' && key !== 'originalFileName',
+        (key) => key !== 'relativePath' && key !== 'originalFileName' && key !== 'uuid',
       );
 
       if (updateFields.length) {
@@ -101,6 +102,7 @@ export class LibraryController implements ILibraryController {
           user,
           relativePath,
           updateObj as unknown as LibraryItem,
+          uuid
         );
       }
 
@@ -202,10 +204,11 @@ export class LibraryController implements ILibraryController {
   ): Promise<IResponse> {
     try {
       const user = req.user;
-      const { relativePath } = req.method === 'POST' ? req.body : req.query;
+      const { relativePath, uuid } = req.method === 'POST' ? req.body : req.query;
       const bookmarks = await this._libraryService.getBookmarks({
         user_id: user.id_user,
         key: relativePath,
+        uuid: uuid
       });
       const response: { bookmarks: Bookmark[]; warning?: string } = {
         bookmarks,
@@ -231,9 +234,13 @@ export class LibraryController implements ILibraryController {
     try {
       const user = req.user;
       const bookmark = req.body as Bookmark;
-      const itemDB = await this._libraryService.dbGetLibrary(user.id_user, bookmark.key, {
-        exactly: true,
-      });
+      const itemDB = bookmark.uuid
+        ? await this._libraryService.dbGetLibraryByUuid(user.id_user, bookmark.uuid, {
+          exactly: true,
+        })
+        : await this._libraryService.dbGetLibrary(user.id_user, bookmark.key, {
+          exactly: true,
+        });
       if (!itemDB || !itemDB[0]) {
         throw new Error('Invalid key');
       }
@@ -265,6 +272,7 @@ export class LibraryController implements ILibraryController {
       const thumbnailData = req.body as {
         thumbnail_name: string;
         relativePath: string;
+        uuid?: string;
         uploaded?: boolean;
       };
       if (!thumbnailData.thumbnail_name || !thumbnailData.relativePath) {
@@ -291,15 +299,17 @@ export class LibraryController implements ILibraryController {
     res: IResponse,
   ): Promise<IResponse> {
     try {
-      const { relativePath, newName } = req.body;
+      const { relativePath, uuid, newName } = req.body;
       if (!relativePath || !newName) {
         throw new Error('Invalid parameters');
       }
       const user = req.user;
       const cleanPath = relativePath.replace(`${user.email}/`, '');
-      const objectDB = await this._libraryService.dbGetLibrary(user.id_user, cleanPath, {
-        exactly: true,
-      });
+      const objectDB = isValidUUID(uuid)
+        ? await this._libraryService.dbGetLibraryByUuid(user.id_user, uuid, { exactly: true })
+        : await this._libraryService.dbGetLibrary(user.id_user, cleanPath, {
+          exactly: true,
+        });
       const itemDb = objectDB[0];
       if (!itemDb) {
         throw Error('Item not found');
@@ -314,6 +324,23 @@ export class LibraryController implements ILibraryController {
       this._logger.log({ origin: 'renameLibraryObject', message: err.message, data: { user: req.user, body: req.body } }, 'error');
       res.status(400).json({ message: err.message });
       return;
+    }
+  }
+
+  public async postLibraryUuids(
+    req: IRequest,
+    res: IResponse,
+  ): Promise<IResponse> {
+    try {
+      const updates = Object.keys(req.body).map(key => ({key, uuid: req.body[key]})); 
+      const { applied, conflicts } = await this._libraryService.processItemUUIDs(updates);
+      // Return both the successes and the conflicts so the client can patch its local DB
+      return res.json({ applied, conflicts });
+
+    } catch (err) {
+      this._logger.log({ origin: 'postLibraryUuids', message: err.message, data: { user: req.user, body: req.body } }, 'error');
+      res.status(400).json({ message: err.message });
+      return
     }
   }
 }

--- a/src/controllers/LibraryController.ts
+++ b/src/controllers/LibraryController.ts
@@ -169,7 +169,11 @@ export class LibraryController implements ILibraryController {
     try {
       const params = req.body;
       const user = req.user;
-      const content = await this._libraryService.moveLibraryObject(user, params);
+      const { origin, destination } = params;
+      const useUuids = (isValidUUID(origin) && isValidUUID(destination) || (isValidUUID(origin) && destination === '') || (isValidUUID(destination) && origin === ''))
+      const content = useUuids
+        ? await this._libraryService.moveLibraryObjectByUuid(user, params)
+        : await this._libraryService.moveLibraryObject(user, params);
       return res.json({ content });
     } catch (err) {
       this._logger.log({ origin: 'moveLibraryObject', message: err.message, data: { user: req.user, body: req.body } }, 'error');
@@ -300,21 +304,22 @@ export class LibraryController implements ILibraryController {
   ): Promise<IResponse> {
     try {
       const { relativePath, uuid, newName } = req.body;
-      if (!relativePath || !newName) {
+      if ((!relativePath && !uuid) || !newName) {
         throw new Error('Invalid parameters');
       }
       const user = req.user;
-      const cleanPath = relativePath.replace(`${user.email}/`, '');
+      const cleanPath = (relativePath || "").replace(`${user.email}/`, '');
       const objectDB = isValidUUID(uuid)
         ? await this._libraryService.dbGetLibraryByUuid(user.id_user, uuid, { exactly: true })
         : await this._libraryService.dbGetLibrary(user.id_user, cleanPath, {
           exactly: true,
         });
       const itemDb = objectDB[0];
+      console.log('HEY HO 0', itemDb.uuid);
       if (!itemDb) {
         throw Error('Item not found');
       }
-
+      console.log('HEY HO', itemDb.uuid);
       const content = await this._libraryService.renameLibraryObject(user, {
         item: itemDb,
         newName,

--- a/src/controllers/LibraryController.ts
+++ b/src/controllers/LibraryController.ts
@@ -170,7 +170,9 @@ export class LibraryController implements ILibraryController {
       const params = req.body;
       const user = req.user;
       const { origin, destination } = params;
-      const useUuids = (isValidUUID(origin) && isValidUUID(destination) || (isValidUUID(origin) && destination === '') || (isValidUUID(destination) && origin === ''))
+      const useUuids = (isValidUUID(origin) && isValidUUID(destination)) 
+        || (isValidUUID(origin) && destination === '') 
+        || (isValidUUID(destination) && origin === '');
       const content = useUuids
         ? await this._libraryService.moveLibraryObjectByUuid(user, params)
         : await this._libraryService.moveLibraryObject(user, params);
@@ -315,11 +317,9 @@ export class LibraryController implements ILibraryController {
           exactly: true,
         });
       const itemDb = objectDB[0];
-      console.log('HEY HO 0', itemDb.uuid);
       if (!itemDb) {
         throw Error('Item not found');
       }
-      console.log('HEY HO', itemDb.uuid);
       const content = await this._libraryService.renameLibraryObject(user, {
         item: itemDb,
         newName,
@@ -337,8 +337,15 @@ export class LibraryController implements ILibraryController {
     res: IResponse,
   ): Promise<IResponse> {
     try {
-      const updates = Object.keys(req.body).map(key => ({key, uuid: req.body[key]})); 
-      const { applied, conflicts } = await this._libraryService.processItemUUIDs(updates);
+      const MAX_RECORDS_LIMIT = 1000;
+      const user = req.user;
+      const processData = req.body as {
+        items: Record<string, string>
+      };
+      if (Object.keys(processData.items).length > MAX_RECORDS_LIMIT) throw new Error(`Too many records, the maximum to process at a time is ${MAX_RECORDS_LIMIT}.`);
+
+      const updates = Object.keys(processData.items).map(key => ({key, uuid: processData.items[key]})); 
+      const { applied, conflicts } = await this._libraryService.processItemUUIDs(user, updates);
       // Return both the successes and the conflicts so the client can patch its local DB
       return res.json({ applied, conflicts });
 

--- a/src/database/migrations/20260304012529_add_uuid_to_library_items.ts
+++ b/src/database/migrations/20260304012529_add_uuid_to_library_items.ts
@@ -1,18 +1,13 @@
-import type { Knex } from "knex";
-
-
+import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
-    return knex.schema.alterTable('library_items', (table) => {
-        table.uuid('uuid').nullable();
-        table.index('uuid');
-    });
+  return knex.schema.alterTable('library_items', (table) => {
+    table.uuid('uuid').nullable();
+    table.unique(['uuid']);
+  });
 }
-
-
 export async function down(knex: Knex): Promise<void> {
-    return knex.schema.alterTable('library_items', (table) => {
-        table.dropIndex('uuid');
-        table.dropColumn('uuid');
-    });
+  return knex.schema.alterTable('library_items', (table) => {
+    table.dropUnique(['uuid']);
+    table.dropColumn('uuid');
+  });
 }
-

--- a/src/database/migrations/20260304012529_add_uuid_to_library_items.ts
+++ b/src/database/migrations/20260304012529_add_uuid_to_library_items.ts
@@ -1,0 +1,18 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('library_items', (table) => {
+        table.uuid('uuid').nullable();
+        table.index('uuid');
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('library_items', (table) => {
+        table.dropIndex('uuid');
+        table.dropColumn('uuid');
+    });
+}
+

--- a/src/interfaces/ILibraryController.ts
+++ b/src/interfaces/ILibraryController.ts
@@ -54,4 +54,8 @@ export interface ILibraryController {
     res: IResponse,
     _: INext,
   ): Promise<IResponse>;
+  postLibraryUuids(
+    req: IRequest, 
+    res: IResponse, _: INext
+  ): Promise<IResponse>;
 }

--- a/src/interfaces/ILibraryService.ts
+++ b/src/interfaces/ILibraryService.ts
@@ -54,8 +54,13 @@ export interface ILibraryService {
     params: {
       origin: string;
       destination: string;
-      originUuid?: string;
-      destinationUuid?: string;
+    },
+  ): Promise<LibraryItemMovedDB[]>;
+  moveLibraryObjectByUuid(
+    user: User,
+    params: {
+      origin?: string;
+      destination?: string;
     },
   ): Promise<LibraryItemMovedDB[]>;
   deleteFolderMoving(user: User, folderPath: string): Promise<boolean>;

--- a/src/interfaces/ILibraryService.ts
+++ b/src/interfaces/ILibraryService.ts
@@ -1,9 +1,11 @@
 import {
   Bookmark,
-  LibrarItemDB,
+  LibraryItemDB,
   LibraryItemMovedDB,
   LibraryItem,
   User,
+  ItemMatchPayload,
+  MatchUuidsResult,
 } from '../types/user';
 
 export interface ILibraryService {
@@ -14,8 +16,16 @@ export interface ILibraryService {
       rawFilter?: string;
       exactly?: boolean;
     },
-  ): Promise<LibrarItemDB[]>;
-  getItemByThumbnail(user_id: number, thumbnail: string): Promise<LibrarItemDB>;
+  ): Promise<LibraryItemDB[]>;
+  dbGetLibraryByUuid(
+    user_id: number,
+    uuid: string,
+    filter?: {
+      rawFilter?: string;
+      exactly?: boolean;
+    },
+  ): Promise<LibraryItemDB[]>;
+  getItemByThumbnail(user_id: number, thumbnail: string): Promise<LibraryItemDB>;
   GetLibrary(
     user: User,
     path: string,
@@ -23,6 +33,7 @@ export interface ILibraryService {
       withPresign?: boolean; // deprecated
       appVersion: string;
     },
+    uuid?: string
   ): Promise<LibraryItem[]>;
   GetObject(
     user: User,
@@ -35,6 +46,7 @@ export interface ILibraryService {
     user: User,
     relativePath: string,
     params: LibraryItem,
+    uuid?: string
   ): Promise<boolean>;
   reOrderObject(user: User, params: LibraryItem): Promise<boolean>;
   moveLibraryObject(
@@ -42,6 +54,8 @@ export interface ILibraryService {
     params: {
       origin: string;
       destination: string;
+      originUuid?: string;
+      destinationUuid?: string;
     },
   ): Promise<LibraryItemMovedDB[]>;
   deleteFolderMoving(user: User, folderPath: string): Promise<boolean>;
@@ -52,12 +66,13 @@ export interface ILibraryService {
       appVersion: string;
     },
   ): Promise<LibraryItem>;
-  getBookmarks(params: { key?: string; user_id: number }): Promise<Bookmark[]>;
+  getBookmarks(params: { key?: string; uuid?: String, user_id: number }): Promise<Bookmark[]>;
   upsertBookmark(bookmark: Bookmark): Promise<Bookmark>;
   thumbailPutRequest(
     user: User,
     params: {
       relativePath: string;
+      uuid?: string;
       thumbnail_name: string;
       uploaded?: boolean;
     },
@@ -65,9 +80,10 @@ export interface ILibraryService {
   renameLibraryObject(
     user: User,
     params: {
-      item: LibrarItemDB;
+      item: LibraryItemDB;
       newName: string;
     },
   ): Promise<LibraryItemMovedDB[]>;
   dbGetAllKeys(user_id: number): Promise<string[]>;
+  processItemUUIDs(updates: ItemMatchPayload[]): Promise<MatchUuidsResult>;
 }

--- a/src/interfaces/ILibraryService.ts
+++ b/src/interfaces/ILibraryService.ts
@@ -59,8 +59,8 @@ export interface ILibraryService {
   moveLibraryObjectByUuid(
     user: User,
     params: {
-      origin?: string;
-      destination?: string;
+      origin: string;
+      destination: string;
     },
   ): Promise<LibraryItemMovedDB[]>;
   deleteFolderMoving(user: User, folderPath: string): Promise<boolean>;
@@ -71,7 +71,7 @@ export interface ILibraryService {
       appVersion: string;
     },
   ): Promise<LibraryItem>;
-  getBookmarks(params: { key?: string; uuid?: String, user_id: number }): Promise<Bookmark[]>;
+  getBookmarks(params: { key?: string; uuid?: string, user_id: number }): Promise<Bookmark[]>;
   upsertBookmark(bookmark: Bookmark): Promise<Bookmark>;
   thumbailPutRequest(
     user: User,
@@ -90,5 +90,5 @@ export interface ILibraryService {
     },
   ): Promise<LibraryItemMovedDB[]>;
   dbGetAllKeys(user_id: number): Promise<string[]>;
-  processItemUUIDs(updates: ItemMatchPayload[]): Promise<MatchUuidsResult>;
+  processItemUUIDs(user: User, updates: ItemMatchPayload[]): Promise<MatchUuidsResult>;
 }

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -487,17 +487,21 @@ export class LibraryService {
         },
         {},
       );
-      await db('library_items')
+      const whereClause = isValidUUID(uuid)
+        ? {
+          user_id,
+          uuid: uuid as string,
+        }
+        : {
+          user_id,
+          key: key,
+        };
+      const updatedCount = await db('library_items')
         .update(updateObject)
-        .where(uuid
-          ? {
-            user_id,
-            uuid: uuid,
-          }
-          : {
-            user_id,
-            key: key,
-          });
+        .where(whereClause);
+
+      if (updatedCount !== 1) throw new Error(`Multiple rows (${updatedCount}) matched the update criteria.`);
+
       return true;
     } catch (err) {
       this._logger.log({
@@ -675,7 +679,7 @@ export class LibraryService {
     try {
       const cleanPath = path.replace(`${user.email}/`, '');
       const objectDB = await this.dbGetLibrary(user.id_user, cleanPath);
-      const itemDb = objectDB[0];
+      const itemDb = objectDB?.[0];
       if (!itemDb) {
         throw Error('Item not found');
       }
@@ -795,7 +799,6 @@ export class LibraryService {
   async DeleteObject(user: User, params: LibraryItem): Promise<string[]> {
     try {
       const { relativePath, uuid } = params;
-      const cleanPath = relativePath.replace(`${user.email}/`, '');
       const deletedObjects = isValidUUID(uuid)
         ? await this.dbDeleteLibraryByUuid({
           user_id: user.id_user,
@@ -803,9 +806,10 @@ export class LibraryService {
         })
         : await this.dbDeleteLibrary({
           user_id: user.id_user,
-          path: cleanPath,
+          path: relativePath.replace(`${user.email}/`, ''),
         });
       const itemDb = deletedObjects[0];
+
       if (!itemDb) {
         const alreadyDeleted = isValidUUID(uuid)
           ? await this.dbDeleteLibraryByUuid({
@@ -815,7 +819,7 @@ export class LibraryService {
           })
           : await this.dbDeleteLibrary({
             user_id: user.id_user,
-            path: cleanPath,
+            path: relativePath.replace(`${user.email}/`, ''),
             active: false,
           });
         return alreadyDeleted?.map((i) => i.key) || [];
@@ -1070,9 +1074,9 @@ export class LibraryService {
     const trx = await this.db.transaction();
     try {
       // Sanitize paths to handle whitespace issues in folder names
-      const [originDB] = await this.dbGetLibraryByUuid(user.id_user, params.origin);
+      const [originDB] = await this.dbGetLibraryByUuid(user.id_user, params.origin, null, trx);
       const [destinationDB] = params.destination
-        ? await this.dbGetLibraryByUuid(user.id_user, params.destination)
+        ? await this.dbGetLibraryByUuid(user.id_user, params.destination, null, trx)
         : [null];
 
       if (!originDB) {
@@ -1106,7 +1110,7 @@ export class LibraryService {
       const dbMoved = await this.dbMoveFiles(
         user.id_user,
         originDB.key,
-        destinationDB.key,
+        destinationDB?.key || '',
         trx,
       );
 
@@ -1381,7 +1385,7 @@ export class LibraryService {
         : await this.dbGetLibrary(user.id_user, cleanPath, {
           exactly: true,
         });
-      const itemDb = objectDB[0];
+      const itemDb = objectDB?.[0];
       if (!itemDb) {
         throw new Error('Item not exists');
       }
@@ -1550,7 +1554,7 @@ export class LibraryService {
     }
   }
 
-  async processItemUUIDs(updates: ItemMatchPayload[]): Promise<MatchUuidsResult> {
+  async processItemUUIDs(user: User, updates: ItemMatchPayload[]): Promise<MatchUuidsResult> {
     const trx = await this.db.transaction();
 
     try {
@@ -1559,7 +1563,9 @@ export class LibraryService {
       // 2. Fetch current state using the 'trx' object
       const existingItems = await trx('library_items')
         .select('key', 'uuid')
-        .whereIn('key', serverKeys);
+        .where({ user_id: user.id_user })
+        .whereIn('key', serverKeys)
+        .forUpdate();
 
       const existingItemsMap = new Map(existingItems.map((item: any) => [item.key, item.uuid]));
 
@@ -1586,7 +1592,10 @@ export class LibraryService {
       if (toUpdate.length > 0) {
         const updatePromises = toUpdate.map(item => 
           trx('library_items')
-            .where('key', item.key)
+            .where({
+              user_id: user.id_user,
+              key: item.key
+            })
             .update({ uuid: item.uuid })
         );
         

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -123,7 +123,7 @@ export class LibraryService {
       return objects;
     } catch (err) {
       this._logger.log({
-        origin: 'dbGetLibrary',
+        origin: 'dbGetLibraryByUuid',
         message: err.message,
         data: { user_id, uuid, filter },
       });
@@ -199,7 +199,7 @@ export class LibraryService {
     trx?: Knex.Transaction,
   ): Promise<LibraryItemDB[]> {
     try {
-      const { user_id, uuid, exactly, active } = params;
+      const { user_id, uuid, active } = params;
       if (!isValidUUID(uuid)) throw Error(`Invalid UUID ${uuid}. Wrong format`);
       const db = trx || this.db;
       const objectsDeleted = await db('library_items as li')
@@ -215,7 +215,7 @@ export class LibraryService {
       return objectsDeleted;
     } catch (err) {
       this._logger.log({
-        origin: 'dbDeleteLibrary',
+        origin: 'dbDeleteLibraryByUuid',
         message: err.message,
         data: params,
       });
@@ -487,10 +487,17 @@ export class LibraryService {
         },
         {},
       );
-      await db('library_items').update(updateObject).where({
-        user_id,
-        key: key,
-      });
+      await db('library_items')
+        .update(updateObject)
+        .where(uuid
+          ? {
+            user_id,
+            uuid: uuid,
+          }
+          : {
+            user_id,
+            key: key,
+          });
       return true;
     } catch (err) {
       this._logger.log({
@@ -789,7 +796,7 @@ export class LibraryService {
     try {
       const { relativePath, uuid } = params;
       const cleanPath = relativePath.replace(`${user.email}/`, '');
-      const deletedObjects = uuid
+      const deletedObjects = isValidUUID(uuid)
         ? await this.dbDeleteLibraryByUuid({
           user_id: user.id_user,
           uuid,
@@ -800,7 +807,7 @@ export class LibraryService {
         });
       const itemDb = deletedObjects[0];
       if (!itemDb) {
-        const alreadyDeleted = uuid
+        const alreadyDeleted = isValidUUID(uuid)
           ? await this.dbDeleteLibraryByUuid({
             user_id: user.id_user,
             uuid,
@@ -843,7 +850,7 @@ export class LibraryService {
     uuid?: string
   ): Promise<boolean> {
     try {
-      const cleanPath = relativePath.replace(`${user.email}/`, '');
+      const cleanPath = (relativePath || "").replace(`${user.email}/`, '');
 
       const libraryItem = (await this.ParseLibraryItemDbB(
         {
@@ -938,8 +945,6 @@ export class LibraryService {
     params: {
       origin: string;
       destination: string;
-      originUuid?: string;
-      destinationUuid?: string;
     },
   ): Promise<LibraryItemMovedDB[]> {
     const trx = await this.db.transaction();
@@ -1048,6 +1053,71 @@ export class LibraryService {
       await trx?.rollback();
       this._logger.log({
         origin: 'moveLibraryObject',
+        message: err.message,
+        data: { user, params },
+      });
+      throw Error(err);
+    }
+  }
+
+  async moveLibraryObjectByUuid(
+    user: User,
+    params: {
+      origin: string;
+      destination: string;
+    },
+  ): Promise<LibraryItemMovedDB[]> {
+    const trx = await this.db.transaction();
+    try {
+      // Sanitize paths to handle whitespace issues in folder names
+      const [originDB] = await this.dbGetLibraryByUuid(user.id_user, params.origin);
+      const [destinationDB] = params.destination
+        ? await this.dbGetLibraryByUuid(user.id_user, params.destination)
+        : [null];
+
+      if (!originDB) {
+        throw Error(
+          `Item not found: "${params.origin}"`,
+        );
+      }
+      
+      if (destinationDB) {
+        const destType = `${destinationDB.type}`;
+        if (
+          destType !== LibraryItemType.FOLDER &&
+          destType !== LibraryItemType.BOUND
+        ) {
+          throw Error('The destination is invalid');
+        }
+      }
+
+      const originFilename = originDB.key.split('/').pop();
+      const expectedDestinationPath =
+        !destinationDB
+          ? originFilename
+          : `${destinationDB.key}/${originFilename}`;
+
+      // If origin and destination are the same, return early
+      if (originDB.key === expectedDestinationPath) {
+        await trx.commit();
+        return [];
+      }
+      
+      const dbMoved = await this.dbMoveFiles(
+        user.id_user,
+        originDB.key,
+        destinationDB.key,
+        trx,
+      );
+
+      await this.processMovedFiles(user, dbMoved, trx);
+
+      await trx.commit();
+      return dbMoved;
+    } catch (err) {
+      await trx?.rollback();
+      this._logger.log({
+        origin: 'moveLibraryObjectByUuid',
         message: err.message,
         data: { user, params },
       });

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -1,13 +1,15 @@
 import { inject, injectable } from 'inversify';
 import {
   Bookmark,
-  LibrarItemDB,
+  LibraryItemDB,
   LibraryItemMovedDB,
   LibraryItem,
   LibraryItemOutput,
   LibraryItemType,
   StorageAction,
   User,
+  ItemMatchPayload,
+  MatchUuidsResult,
 } from '../types/user';
 import { Knex } from 'knex';
 import database from '../database';
@@ -19,6 +21,7 @@ import {
   splitArrayGroups,
   detectExcessiveFolderNesting,
   sanitizeLibraryPath,
+  isValidUUID,
 } from '../utils';
 
 @injectable()
@@ -58,7 +61,7 @@ export class LibraryService {
       exactly?: boolean;
     },
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB[]> {
+  ): Promise<LibraryItemDB[]> {
     try {
       const db = trx || this.db;
       const pathNumber = path.split('/').length;
@@ -91,11 +94,48 @@ export class LibraryService {
     }
   }
 
+  async dbGetLibraryByUuid(
+    user_id: number,
+    uuid: string,
+    filter?: {
+      rawFilter?: string;
+      exactly?: boolean;
+    },
+    trx?: Knex.Transaction,
+  ): Promise<LibraryItemDB[]> {
+    try {
+      const db = trx || this.db;
+      const objects = await db('library_items as li')
+        .where({
+          user_id,
+          active: true,
+          uuid
+        })
+        .andWhere((builder) => {
+          if (!!filter?.rawFilter) {
+            builder.whereRaw(filter?.rawFilter);
+          } else {
+            builder.where(true);
+          }
+        })
+        .orderBy('order_rank', 'asc')
+        .debug(false);
+      return objects;
+    } catch (err) {
+      this._logger.log({
+        origin: 'dbGetLibrary',
+        message: err.message,
+        data: { user_id, uuid, filter },
+      });
+      return null;
+    }
+  }
+
   async getItemByThumbnail(
     user_id: number,
     thumbnail: string,
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB> {
+  ): Promise<LibraryItemDB> {
     try {
       const db = trx || this.db;
       const item = await db('library_items as li')
@@ -124,7 +164,7 @@ export class LibraryService {
       active?: boolean;
     },
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB[]> {
+  ): Promise<LibraryItemDB[]> {
     try {
       const { user_id, path, exactly, active } = params;
       const db = trx || this.db;
@@ -149,11 +189,45 @@ export class LibraryService {
     }
   }
 
+  async dbDeleteLibraryByUuid(
+    params: {
+      user_id: number;
+      uuid: string;
+      exactly?: boolean;
+      active?: boolean;
+    },
+    trx?: Knex.Transaction,
+  ): Promise<LibraryItemDB[]> {
+    try {
+      const { user_id, uuid, exactly, active } = params;
+      if (!isValidUUID(uuid)) throw Error(`Invalid UUID ${uuid}. Wrong format`);
+      const db = trx || this.db;
+      const objectsDeleted = await db('library_items as li')
+        .update({
+          active: false,
+        })
+        .where({
+          user_id,
+          uuid,
+          active: active === false ? active : true,
+        })
+        .returning('*');
+      return objectsDeleted;
+    } catch (err) {
+      this._logger.log({
+        origin: 'dbDeleteLibrary',
+        message: err.message,
+        data: params,
+      });
+      return null;
+    }
+  }
+
   async dbNestedObjects(
     user_id: number,
     folderPath: string,
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB[]> {
+  ): Promise<LibraryItemDB[]> {
     try {
       const db = trx || this.db;
       const nestedObjects = await db
@@ -320,7 +394,7 @@ export class LibraryService {
     user_id: number,
     folderPath: string,
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB[]> {
+  ): Promise<LibraryItemDB[]> {
     try {
       const db = trx || this.db;
       const objectsMoved = await db
@@ -356,9 +430,9 @@ export class LibraryService {
 
   async dbInsertLibraryItem(
     user_id: number,
-    item: LibrarItemDB,
+    item: LibraryItemDB,
     trx?: Knex.Transaction,
-  ): Promise<LibrarItemDB> {
+  ): Promise<LibraryItemDB> {
     try {
       const db = trx || this.db;
       const objects = await db('library_items as li')
@@ -380,6 +454,7 @@ export class LibraryService {
           is_finish: item.is_finish,
           thumbnail: item.thumbnail || null,
           source_path: item.source_path,
+          uuid: item.uuid
         })
         .returning('*');
       return objects[0];
@@ -396,7 +471,8 @@ export class LibraryService {
   async dbUpdateLibraryItem(
     user_id: number,
     key: string,
-    item: LibrarItemDB,
+    item: LibraryItemDB,    
+    uuid?: string,
     trx?: Knex.Transaction,
   ): Promise<boolean> {
     try {
@@ -433,10 +509,13 @@ export class LibraryService {
       withPresign?: boolean; // deprecated
       appVersion: string;
     },
+    uuid?: string
   ): Promise<LibraryItem[]> {
     try {
       const cleanPath = path.replace(`${user.email}/`, '');
-      const objectDB = await this.dbGetLibrary(user.id_user, cleanPath);
+      const objectDB = isValidUUID(uuid)
+        ? await this.dbGetLibraryByUuid(user.id_user, uuid)
+        : await this.dbGetLibrary(user.id_user, cleanPath);
       const library: LibraryItem[] = [];
       if (objectDB?.length) {
         for (let index = 0; index < objectDB.length; index++) {
@@ -479,6 +558,7 @@ export class LibraryService {
           }
 
           const libObj: LibraryItem = {
+            uuid: itemDb.uuid,
             relativePath: itemDb.key,
             originalFileName: itemDb.original_filename,
             title: itemDb.title,
@@ -512,13 +592,13 @@ export class LibraryService {
   }
 
   async ParseLibraryItemDbB(
-    item: LibrarItemDB | LibraryItem,
+    item: LibraryItemDB | LibraryItem,
     output: LibraryItemOutput,
-  ): Promise<LibrarItemDB | LibraryItem> {
-    let parsed: LibraryItem | LibrarItemDB;
+  ): Promise<LibraryItemDB | LibraryItem> {
+    let parsed: LibraryItem | LibraryItemDB;
     switch (output) {
       case LibraryItemOutput.API:
-        const itemTemp = item as LibrarItemDB;
+        const itemTemp = item as LibraryItemDB;
         parsed = {
           relativePath: itemTemp.key,
           originalFileName: itemTemp.original_filename,
@@ -538,6 +618,7 @@ export class LibraryService {
           url: '',
           synced: itemTemp.synced,
           source_path: itemTemp.source_path,
+          uuid: itemTemp.uuid
         };
         break;
       case LibraryItemOutput.DB:
@@ -572,6 +653,7 @@ export class LibraryService {
           thumbnail: itemApi.thumbnail,
           synced: itemApi.synced !== undefined ? itemApi.synced : undefined,
           source_path: itemApi.source_path,
+          uuid: itemApi.uuid
         };
         break;
     }
@@ -656,7 +738,7 @@ export class LibraryService {
       const libObj = (await this.ParseLibraryItemDbB(
         params,
         LibraryItemOutput.DB,
-      )) as LibrarItemDB;
+      )) as LibraryItemDB;
 
       const cleanPath = relativePath.replace(`${user.email}/`, '');
       const objectDB = await this.dbGetLibrary(user.id_user, cleanPath, {
@@ -705,19 +787,30 @@ export class LibraryService {
 
   async DeleteObject(user: User, params: LibraryItem): Promise<string[]> {
     try {
-      const { relativePath } = params;
+      const { relativePath, uuid } = params;
       const cleanPath = relativePath.replace(`${user.email}/`, '');
-      const deletedObjects = await this.dbDeleteLibrary({
-        user_id: user.id_user,
-        path: cleanPath,
-      });
-      const itemDb = deletedObjects[0];
-      if (!itemDb) {
-        const alreadyDeleted = await this.dbDeleteLibrary({
+      const deletedObjects = uuid
+        ? await this.dbDeleteLibraryByUuid({
+          user_id: user.id_user,
+          uuid,
+        })
+        : await this.dbDeleteLibrary({
           user_id: user.id_user,
           path: cleanPath,
-          active: false,
         });
+      const itemDb = deletedObjects[0];
+      if (!itemDb) {
+        const alreadyDeleted = uuid
+          ? await this.dbDeleteLibraryByUuid({
+            user_id: user.id_user,
+            uuid,
+            active: false,
+          })
+          : await this.dbDeleteLibrary({
+            user_id: user.id_user,
+            path: cleanPath,
+            active: false,
+          });
         return alreadyDeleted?.map((i) => i.key) || [];
       }
 
@@ -747,6 +840,7 @@ export class LibraryService {
     user: User,
     relativePath: string,
     params: LibraryItem,
+    uuid?: string
   ): Promise<boolean> {
     try {
       const cleanPath = relativePath.replace(`${user.email}/`, '');
@@ -757,11 +851,12 @@ export class LibraryService {
           ...params,
         },
         LibraryItemOutput.DB,
-      )) as LibrarItemDB;
+      )) as LibraryItemDB;
       const result = await this.dbUpdateLibraryItem(
         user.id_user,
         cleanPath,
         libraryItem,
+        uuid
       );
 
       return result;
@@ -821,6 +916,7 @@ export class LibraryService {
           ...objectDB[0],
           order_rank: orderRank,
         },
+        null,
         trx,
       );
       await trx.commit();
@@ -842,6 +938,8 @@ export class LibraryService {
     params: {
       origin: string;
       destination: string;
+      originUuid?: string;
+      destinationUuid?: string;
     },
   ): Promise<LibraryItemMovedDB[]> {
     const trx = await this.db.transaction();
@@ -1021,7 +1119,6 @@ export class LibraryService {
                 targetKey,
               });
               if (isMoved) {
-                console.log('is moved', isMoved, original_filename, fileMoved);
                 await trx('library_items')
                   .update({
                     source_path: original_filename,
@@ -1126,16 +1223,20 @@ export class LibraryService {
   async getBookmarks(
     params: {
       key?: string;
+      uuid?: string;
       user_id: number;
     },
     trx?: Knex.Transaction,
   ): Promise<Bookmark[]> {
     try {
-      const { key, user_id } = params;
+      const { key, user_id, uuid } = params;
       const db = trx || this.db;
       const filter: (number | string)[] = [user_id];
       let whereFilter = '';
-      if (key) {
+      if (uuid && isValidUUID(uuid)) {
+        filter.push(uuid);
+        whereFilter += ' and li.uuid=? ';
+      } else if (key) {
         filter.push(key);
         whereFilter += ' and li.key=? ';
       }
@@ -1195,16 +1296,21 @@ export class LibraryService {
     user: User,
     params: {
       relativePath: string;
+      uuid?: string;
       thumbnail_name: string;
       uploaded?: boolean;
     },
   ): Promise<string | boolean> {
     try {
-      const { relativePath, thumbnail_name, uploaded } = params;
+      const { relativePath, uuid, thumbnail_name, uploaded } = params;
       const cleanPath = relativePath.replace(`${user.email}/`, '');
-      const objectDB = await this.dbGetLibrary(user.id_user, cleanPath, {
-        exactly: true,
-      });
+      const objectDB = isValidUUID(uuid)
+        ? await this.dbGetLibraryByUuid(user.id_user, uuid, {
+          exactly: true,
+        })
+        : await this.dbGetLibrary(user.id_user, cleanPath, {
+          exactly: true,
+        });
       const itemDb = objectDB[0];
       if (!itemDb) {
         throw new Error('Item not exists');
@@ -1238,7 +1344,7 @@ export class LibraryService {
   async renameLibraryObject(
     user: User,
     params: {
-      item: LibrarItemDB;
+      item: LibraryItemDB;
       newName: string;
     },
   ): Promise<LibraryItemMovedDB[]> {
@@ -1371,6 +1477,65 @@ export class LibraryService {
         data: { user, params },
       });
       throw Error(err);
+    }
+  }
+
+  async processItemUUIDs(updates: ItemMatchPayload[]): Promise<MatchUuidsResult> {
+    const trx = await this.db.transaction();
+
+    try {
+      const serverKeys = updates.map(u => u.key);
+      
+      // 2. Fetch current state using the 'trx' object
+      const existingItems = await trx('library_items')
+        .select('key', 'uuid')
+        .whereIn('key', serverKeys);
+
+      const existingItemsMap = new Map(existingItems.map((item: any) => [item.key, item.uuid]));
+
+      const conflicts: ItemMatchPayload[] = [];
+      const applied: string[] = [];
+      const toUpdate: ItemMatchPayload[] = [];
+
+      // 3. Sort into conflicts and safe updates
+      for (const item of updates) {
+        const currentUuid = existingItemsMap.get(item.key);
+        
+        if (currentUuid === undefined || currentUuid === item.uuid) continue;
+
+        if (currentUuid !== null) {
+          if (currentUuid !== item.uuid) {
+              conflicts.push({ key: item.uuid, uuid: currentUuid });
+          }
+        } else {
+          toUpdate.push(item);
+        }
+      }
+
+      // 4. Perform updates using the 'trx' object
+      if (toUpdate.length > 0) {
+        const updatePromises = toUpdate.map(item => 
+          trx('library_items')
+            .where('key', item.key)
+            .update({ uuid: item.uuid })
+        );
+        
+        await Promise.all(updatePromises);
+        
+        toUpdate.forEach(item => applied.push(item.uuid));
+      }
+
+      // 5. Commit the transaction if everything succeeded
+      await trx.commit();
+
+      return { applied, conflicts };
+
+    } catch (error) {
+      // 6. Rollback the transaction if any error occurs
+      await trx.rollback();
+      
+      // Re-throw the error so your Express route catch-block can return a 500 status
+      throw error; 
     }
   }
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -145,6 +145,7 @@ export interface LibraryItem {
   thumbnail?: string;
   synced?: boolean;
   source_path?: string;
+  uuid?: string;
 }
 
 export interface LibraryItemMovedDB {
@@ -156,7 +157,7 @@ export interface LibraryItemMovedDB {
   source_path?: string;
 }
 
-export interface LibrarItemDB {
+export interface LibraryItemDB {
   id_library_item?: number;
   user_id?: number;
   key: string;
@@ -175,6 +176,7 @@ export interface LibrarItemDB {
   active?: boolean;
   synced: boolean;
   source_path?: string;
+  uuid?: string;
 }
 
 export interface StorageItem {
@@ -197,6 +199,7 @@ export enum StorageOrigin {
 export interface Bookmark {
   title?: string;
   key: string;
+  uuid?: string;
   note?: string;
   time: number;
   library_item_id?: number;
@@ -261,4 +264,14 @@ export interface UserEvent {
   event_name: UserEventEnum;
   event_data: object;
   created_at: string;
+}
+
+export interface ItemMatchPayload {
+  key: string;
+  uuid: string;
+}
+
+export interface MatchUuidsResult {
+  applied: string[];
+  conflicts: ItemMatchPayload[];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,19 @@ export const sanitizeLibraryPath = (path: string): string => {
     .join('/');
 };
 
+/**
+ * Check if uuid is valid
+ * @param uuid - The uuid to check 
+ * @returns boolean whether it is valid or not
+ */
+export function isValidUUID(uuid?: string): boolean {
+  if (!uuid) return false;
+  
+  const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+  
+  return uuidRegex.test(uuid);
+}
+
 export const splitArrayGroups = (array: unknown[], chunkSize: number) => {
   const chunks = [];
   for (let i = 0; i < array.length; i += chunkSize) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,15 +17,15 @@ export const sanitizeLibraryPath = (path: string): string => {
 
 /**
  * Check if uuid is valid
- * @param uuid - The uuid to check 
+ * @param testUuid - The uuid to check 
  * @returns boolean whether it is valid or not
  */
-export function isValidUUID(uuid?: string): boolean {
-  if (!uuid) return false;
+export function isValidUUID(testUuid?: string): boolean {
+  if (!testUuid) return false;
   
-  const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
-  
-  return uuidRegex.test(uuid);
+  const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  return UUID_REGEX.test(testUuid);
 }
 
 export const splitArrayGroups = (array: unknown[], chunkSize: number) => {


### PR DESCRIPTION
## Purpose

- Assign uuids to library items, this way it is easier to map actions independently of where the items are

## Approach

- Generate optional uuids to avoid breaking current db status
- Sync batches of library items, reporting their local uuid or reassigning the existing server-side uuid
- Handle actions that come with uuid

## Things to be aware of / Things to focus on

- Persisting both relativePath and uuid for legacy actions